### PR TITLE
fix dedupe for many duplicates

### DIFF
--- a/pocketsnack/pocketsnack.py
+++ b/pocketsnack/pocketsnack.py
@@ -255,7 +255,7 @@ try:
         "-a", "--archive", action="store_true", help="get information on TBR items in archive (with -i) or purge tags in archive (with -p)"
     )
     mex.add_argument(
-        "-b", "--all", action="store_true", help="purge all tags in both list and archive (with -p)"
+        "-b", "--all", action="store_true", help="purge all tags in both list and archive (with -p) or dedupe both list and archive (with --dedupe)"
     )
     actions.add_argument(
         "-c", "--config", action="store_true", help="create or edit your config file stored at ~/.pocketsnack_conf.yml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pocketsnack"
-version = "3.1.0b0"
+version = "3.1.0b1"
 description = "KonMari your Pocket tsundoku from the command line"
 authors = ["Hugh Rundle <hugh@hughrundle.net>"]
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
`--dedupe` was failing for deduping large number of duplicates (due to the http string being too long). Now it doesn't.